### PR TITLE
Add support for multiple redirect urls in OIDC

### DIFF
--- a/lib/OpenIDConnect/Repositories/ClientRepository.php
+++ b/lib/OpenIDConnect/Repositories/ClientRepository.php
@@ -22,7 +22,9 @@ class ClientRepository implements ClientRepositoryInterface
         $client = new ClientEntity();
         $client->setIdentifier($tool->oidc_client_id);
         $client->setName($tool->name);
-        $client->setRedirectUri($tool->oidc_redirect_url);
+        $client->setRedirectUri(
+            explode("\n", $tool->oidc_redirect_url)
+        );
         $client->setConfidential(true);
 
         return $client;

--- a/lib/OpenIDConnect/Repositories/ClientRepository.php
+++ b/lib/OpenIDConnect/Repositories/ClientRepository.php
@@ -4,6 +4,7 @@ namespace KIToolbox\OpenIDConnect\Repositories;
 
 use KIToolbox\models\Tool;
 use KIToolbox\OpenIDConnect\Entities\ClientEntity;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 
 class ClientRepository implements ClientRepositoryInterface
@@ -19,12 +20,18 @@ class ClientRepository implements ClientRepositoryInterface
             return null;
         }
 
-        $redirect_urls = $tool->oidc_redirect_url ? explode("\n", $tool->oidc_redirect_url) : $tool->oidc_redirect_url;
+        if (empty($tool->oidc_redirect_url)) {
+            throw OAuthServerException::serverError(
+                'No OIDC redirect URLs are configured for this client.'
+            );
+        }
 
         $client = new ClientEntity();
         $client->setIdentifier($tool->oidc_client_id);
         $client->setName($tool->name);
-        $client->setRedirectUri($redirect_urls);
+        $client->setRedirectUri(
+            explode("\n", $tool->oidc_redirect_url)
+        );
         $client->setConfidential(true);
 
         return $client;

--- a/lib/OpenIDConnect/Repositories/ClientRepository.php
+++ b/lib/OpenIDConnect/Repositories/ClientRepository.php
@@ -19,12 +19,12 @@ class ClientRepository implements ClientRepositoryInterface
             return null;
         }
 
+        $redirect_urls = $tool->oidc_redirect_url ? explode("\n", $tool->oidc_redirect_url) : $tool->oidc_redirect_url;
+
         $client = new ClientEntity();
         $client->setIdentifier($tool->oidc_client_id);
         $client->setName($tool->name);
-        $client->setRedirectUri(
-            explode("\n", $tool->oidc_redirect_url)
-        );
+        $client->setRedirectUri($redirect_urls);
         $client->setConfidential(true);
 
         return $client;

--- a/src/components/admin/TheAdminToolTable.vue
+++ b/src/components/admin/TheAdminToolTable.vue
@@ -6,6 +6,7 @@ import StudipIcon from '../studip/StudipIcon.vue';
 import { useGettext } from 'vue3-gettext';
 import { useToolsStore } from './../../stores/tools';
 import StudipWysiwyg from '../studip/StudipWysiwyg.vue';
+import StudipTooltipIcon from "../studip/StudipTooltipIcon.vue";
 const { $gettext } = useGettext();
 
 const openRemoveDialog = ref(false);
@@ -266,8 +267,9 @@ const createTool = () => {
                             <input type="text" v-model="currentTool.oidc_client_secret" />
                         </label>
                         <label>
-                            {{ $gettext('OIDC Redirect URL') }}
-                            <input type="url" v-model="currentTool.oidc_redirect_url" />
+                            {{ $gettext('OIDC Redirect URLs') }}
+                            <studip-tooltip-icon :text="$gettext('Eine URL pro Zeile')" />
+                            <textarea v-model="currentTool.oidc_redirect_url" />
                         </label>
                     </div>
                     <div v-show="currentTool.auth_method === 'jwt'">
@@ -321,8 +323,9 @@ const createTool = () => {
                             <input type="text" v-model="newTool.oidc_client_secret" />
                         </label>
                         <label>
-                            {{ $gettext('OIDC Redirect URL') }}
-                            <input type="url" v-model="newTool.oidc_redirect_url" />
+                            {{ $gettext('OIDC Redirect URLs') }}
+                            <studip-tooltip-icon :text="$gettext('Eine URL pro Zeile')" />
+                            <textarea v-model="newTool.oidc_redirect_url" />
                         </label>
                     </div>
                     <div v-show="newTool.auth_method === 'jwt'">

--- a/src/components/studip/StudipTooltipIcon.vue
+++ b/src/components/studip/StudipTooltipIcon.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+    text: String,
+    isHtml: {
+        type: Boolean,
+        required: false,
+        default: false
+    },
+    isImportant: {
+        type: Boolean,
+        required: false,
+        default: false
+    },
+});
+
+const cssClass = computed(() => props.isImportant ? 'tooltip-important' : '');
+</script>
+
+<template>
+    <span data-tooltip class="tooltip tooltip-icon" :class="cssClass" tabindex="0">
+        <span class="tooltip-content" v-if="isHtml" v-html="text"></span>
+        <span class="tooltip-content" v-else>{{ text }}</span>
+    </span>
+</template>


### PR DESCRIPTION
Allows multiple redirect URLs to be set in the OIDC provider. This allows a tool to send different redirect urls, useful if you have multiple hosts like `tool.uos.de` and `tool.uni-osnabrueck.de`.